### PR TITLE
Migrate upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,14 @@ jobs:
         run: ./dev.py js-build
 
       - name: Run e2e tests
-        run: pytest e2e
+        run: pytest e2e --screenshot only-on-failure --output ./test-results/
 
       - name: Upload snapshots
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: Snapshots
-          path: e2e/__snapshots__
+          path: e2e/test-results
           if-no-files-found: error
 
       - name: Build package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./dev.py js-build
 
       - name: Run e2e tests
-        run: pytest e2e --browser webkit --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto -r aR -v
+        run: pytest e2e --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto -r aR -v
 
       - name: Upload snapshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,14 @@ jobs:
         run: ./dev.py js-build
 
       - name: Run e2e tests
-        run: |
-          pytest e2e --video retain-on-failure --screenshot only-on-failure \
-          --output ./test-results/ -n auto -r aR -v
+        run: >-
+          pytest e2e
+          --video retain-on-failure
+          --screenshot only-on-failure
+          --output ./test-results/
+          -n auto
+          -r aR
+          -v
 
       - name: Upload snapshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: pytest e2e
 
       - name: Upload snapshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: Snapshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
         run: ./dev.py js-build
 
       - name: Run e2e tests
-        run: pytest e2e --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto -r aR -v
+        run: |
+          pytest e2e --video retain-on-failure --screenshot only-on-failure \
+          --output ./test-results/ -n auto -r aR -v
 
       - name: Upload snapshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./dev.py js-build
 
       - name: Run e2e tests
-        run: pytest e2e --screenshot only-on-failure --output ./test-results/
+        run: pytest e2e --browser webkit --video retain-on-failure --screenshot only-on-failure --output ./test-results/ -n auto -r aR -v
 
       - name: Upload snapshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           --video retain-on-failure
           --screenshot only-on-failure
           --output ./test-results/
-          -n auto
           -r aR
           -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           pytest e2e
           --video retain-on-failure
           --screenshot only-on-failure
+          --update-snapshots
           --output ./test-results/
           -r aR
           -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: Snapshots
-          path: e2e/test-results
+          path: test-results
           if-no-files-found: error
 
       - name: Build package


### PR DESCRIPTION
v3 has been deprecated and will be removed, so we will update this to v4. Based on the breaking changes, I believe we can just update the version.